### PR TITLE
Fix a bug in sublist where rows would not retain their parent columns.

### DIFF
--- a/lib/src/commands/sublist.dart
+++ b/lib/src/commands/sublist.dart
@@ -8,8 +8,10 @@ class SublistHolder {
   SublistHolder(this.path);
 
   SublistListQueryProcessor listProcessor;
+  StreamController<QueryUpdate> controller;
+
   StreamSubscription<QueryUpdate> listSub;
-  List<String> _handles = <String>[];
+  Map<String, QueryUpdate> _handles = <String, QueryUpdate>{};
 
   Iterable<String> destroy() {
     if (listSub != null) {
@@ -17,7 +19,26 @@ class SublistHolder {
       listSub = null;
     }
 
-    return _handles;
+    if (controller != null) {
+      controller.close();
+      controller = null;
+    }
+
+    return _handles.keys;
+  }
+
+  void onOldUpdate() {
+    if (oldUpdate == null) {
+      return;
+    }
+
+    for (String key in _handles.keys.toList()) {
+      var lastToSend = _handles[key];
+      var newUpdateToSend = lastToSend.cloneAndMerge(oldUpdate.values);
+      newUpdateToSend.values["path"] = lastToSend.values["path"];
+      controller.add(newUpdateToSend);
+      _handles[key] = newUpdateToSend;
+    }
   }
 
   QueryStream create(SublistQueryProcessor sublist) {
@@ -32,12 +53,6 @@ class SublistHolder {
       }
       rp += np;
 
-      if (update.remove) {
-        _handles.remove(rp);
-      } else if (!_handles.contains(rp)) {
-        _handles.add(rp);
-      }
-
       var out = update;
 
       if (oldUpdate != null) {
@@ -49,6 +64,12 @@ class SublistHolder {
       });
 
       out.setAttribute("nodePath", rp);
+
+      if (update.remove) {
+        _handles.remove(rp);
+      } else if (!_handles.containsKey(rp)) {
+        _handles[rp] = out;
+      }
 
       return out;
     });
@@ -120,18 +141,20 @@ class SublistQueryProcessor extends QueryProcessor {
           }
         }
       } else {
-        if (!holders.containsKey(path)) {
-          var holder = new SublistHolder(path);
+        SublistHolder holder = holders[path];
+
+        if (holder == null) {
+          holder = new SublistHolder(path);
+
           holder.listSub = holder.create(this).listen((QueryUpdate update) {
             controller.add(update);
           });
 
-          holder.oldUpdate = update;
+          holder.controller = controller;
           holders[path] = holder;
-        } else {
-          SublistHolder holder = holders[path];
-          holder.oldUpdate = update;
         }
+        holder.oldUpdate = update;
+        holder.onOldUpdate();
       }
     };
 

--- a/lib/src/commands/sublist.dart
+++ b/lib/src/commands/sublist.dart
@@ -3,6 +3,8 @@ part of dslink.dql.query;
 class SublistHolder {
   final String path;
 
+  QueryUpdate oldUpdate;
+
   SublistHolder(this.path);
 
   SublistListQueryProcessor listProcessor;
@@ -36,7 +38,13 @@ class SublistHolder {
         _handles.add(rp);
       }
 
-      var out = update.cloneAndMerge({
+      var out = update;
+
+      if (oldUpdate != null) {
+        out = out.cloneAndMerge(oldUpdate.values);
+      }
+
+      out = out.cloneAndMerge({
         "path": rp
       });
 
@@ -112,17 +120,18 @@ class SublistQueryProcessor extends QueryProcessor {
           }
         }
       } else {
-        // We don't care about updates. Paths don't really change.
-        if (holders.containsKey(path)) {
-          return;
+        if (!holders.containsKey(path)) {
+          var holder = new SublistHolder(path);
+          holder.listSub = holder.create(this).listen((QueryUpdate update) {
+            controller.add(update);
+          });
+
+          holder.oldUpdate = update;
+          holders[path] = holder;
+        } else {
+          SublistHolder holder = holders[path];
+          holder.oldUpdate = update;
         }
-
-        var holder = new SublistHolder(path);
-        holder.listSub = holder.create(this).listen((QueryUpdate update) {
-          controller.add(update);
-        });
-
-        holders[path] = holder;
       }
     };
 

--- a/test/integration/query_test.dart
+++ b/test/integration/query_test.dart
@@ -222,35 +222,31 @@ mockTests() {
   test("sublist works as expected", () async {
     var ctx = createPCSCQueryContext();
 
-    doWork(int i) async {
-      var result = await ctx.capture(
-        r"list /downstream/PCSC Security/? | subscribe :name as Node | sublist /Cards/? | subscribe :name as Card"
-      );
+    var result = await ctx.capture(
+      r"list /downstream/PCSC Security/? | subscribe :name as Node | sublist /Cards/? | subscribe :name as Card"
+    );
 
-      result.verify([
-        {
-          "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010137",
-          "Node": "PCSC_ATL110",
-          "Card": "000000010137"
-        },
-        {
-          "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010136",
-          "Node": "PCSC_ATL110",
-          "Card": "000000010136"
-        },
-        {
-          "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010137",
-          "Node": "PCSC_ATL112",
-          "Card": "000000010137"
-        },
-        {
-          "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010136",
-          "Node": "PCSC_ATL112",
-          "Card": "000000010136"
-        }
-      ]);
-    }
-
-    await Future.wait([doWork(1), doWork(2), doWork(3)]);
+    result.verify([
+      {
+        "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010137",
+        "Node": "PCSC_ATL110",
+        "Card": "000000010137"
+      },
+      {
+        "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010136",
+        "Node": "PCSC_ATL110",
+        "Card": "000000010136"
+      },
+      {
+        "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010137",
+        "Node": "PCSC_ATL112",
+        "Card": "000000010137"
+      },
+      {
+        "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010136",
+        "Node": "PCSC_ATL112",
+        "Card": "000000010136"
+      }
+    ]);
   });
 }

--- a/test/integration/query_test.dart
+++ b/test/integration/query_test.dart
@@ -83,6 +83,41 @@ MockQueryContext createDeepQueryContext() {
   return ctx;
 }
 
+MockQueryContext createPCSCQueryContext() {
+  var ctx = createQueryContext({
+    "downstream": {
+      "PCSC Security": {
+        "PCSC_ATL110": {
+          "Cards": {
+            "000000010137": {
+              r"$type": "string",
+              "?value": "234238"
+            },
+            "000000010136": {
+              r"$type": "string",
+              "?value": "234238"
+            }
+          }
+        },
+        "PCSC_ATL112": {
+          "Cards": {
+            "000000010137": {
+              r"$type": "string",
+              "?value": "234238"
+            },
+            "000000010136": {
+              r"$type": "string",
+              "?value": "234238"
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return ctx;
+}
+
 mockTests() {
   test("listing a direct path to a node only yields the children", () async {
     var ctx = createDeepQueryContext();
@@ -177,6 +212,41 @@ mockTests() {
         {
           "path": "${_base}/b",
           "value": 21
+        }
+      ]);
+    }
+
+    await Future.wait([doWork(1), doWork(2), doWork(3)]);
+  });
+
+  test("sublist works as expected", () async {
+    var ctx = createPCSCQueryContext();
+
+    doWork(int i) async {
+      var result = await ctx.capture(
+        r"list /downstream/PCSC Security/? | subscribe :name as Node | sublist /Cards/? | subscribe :name as Card"
+      );
+
+      result.verify([
+        {
+          "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010137",
+          "Node": "PCSC_ATL110",
+          "Card": "000000010137"
+        },
+        {
+          "path": "/downstream/PCSC Security/PCSC_ATL110/Cards/000000010136",
+          "Node": "PCSC_ATL110",
+          "Card": "000000010136"
+        },
+        {
+          "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010137",
+          "Node": "PCSC_ATL112",
+          "Card": "000000010137"
+        },
+        {
+          "path": "/downstream/PCSC Security/PCSC_ATL112/Cards/000000010136",
+          "Node": "PCSC_ATL112",
+          "Card": "000000010136"
         }
       ]);
     }


### PR DESCRIPTION
A query such as:
```
list /downstream/PCSC Security/? | subscribe :name as Node | sublist /Cards/? | subscribe :name as Card
```

did not work as expected, because the sublist would not retain the `Node` column. This is fixed with this update.
